### PR TITLE
Fixes #74, Qt xcb plugin error

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
     - hydra-core==0.11.3
     - omegaconf==1.4.1
     - matplotlib
-    - opencv-python
+    - opencv-python-headless
     - opencv-transforms==0.0.3.post2
     - pandas
     - scikit-learn


### PR DESCRIPTION
Use `opencv-python-headless` instead of `opencv-python`