### PR TITLE
Adding support for Pytorch 2.x and Pytorch-Lightning 2.0.7

### DIFF
--- a/deepethogram/base.py
+++ b/deepethogram/base.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from omegaconf import DictConfig, OmegaConf
 import pytorch_lightning as pl
+from pytorch_lightning.callbacks.progress import TQDMProgressBar
 try:
     from ray.tune.integration.pytorch_lightning import TuneReportCallback, \
         TuneReportCheckpointCallback
@@ -275,8 +276,7 @@ def get_trainer_from_cfg(cfg: DictConfig, lightning_module, stopper, profiler: s
     # learning rate schedule.
 
     if cfg.compute.batch_size == 'auto' or cfg.train.lr == 'auto':
-        trainer = pl.Trainer(gpus=[cfg.compute.gpu_id],
-                             precision=16 if cfg.compute.fp16 else 32,
+        trainer = pl.Trainer(precision=16 if cfg.compute.fp16 else 32,
                              limit_train_batches=1.0,
                              limit_val_batches=1.0,
                              limit_test_batches=1.0,
@@ -378,13 +378,13 @@ def get_trainer_from_cfg(cfg: DictConfig, lightning_module, stopper, profiler: s
     else:
         tensorboard_logger = pl.loggers.tensorboard.TensorBoardLogger(os.getcwd())
         refresh_rate = 1
+        callback_list.append(TQDMProgressBar(refresh_rate=refresh_rate))
 
     # tuning messes with the callbacks
     try:
         # will be deprecated in the future; pytorch lightning updated their kwargs for this function
         # don't like how they keep updating the api without proper deprecation warnings, etc.
-        trainer = pl.Trainer(gpus=[cfg.compute.gpu_id],
-                             precision=16 if cfg.compute.fp16 else 32,
+        trainer = pl.Trainer(precision=16 if cfg.compute.fp16 else 32,
                              limit_train_batches=steps_per_epoch['train'],
                              limit_val_batches=steps_per_epoch['val'],
                              limit_test_batches=steps_per_epoch['test'],
@@ -393,13 +393,11 @@ def get_trainer_from_cfg(cfg: DictConfig, lightning_module, stopper, profiler: s
                              num_sanity_val_steps=0,
                              callbacks=callback_list,
                              reload_dataloaders_every_epoch=True,
-                             progress_bar_refresh_rate=refresh_rate,
                              profiler=profiler,
                              log_every_n_steps=1)
 
     except TypeError:
-        trainer = pl.Trainer(gpus=[cfg.compute.gpu_id],
-                             precision=16 if cfg.compute.fp16 else 32,
+        trainer = pl.Trainer(precision=16 if cfg.compute.fp16 else 32,
                              limit_train_batches=steps_per_epoch['train'],
                              limit_val_batches=steps_per_epoch['val'],
                              limit_test_batches=steps_per_epoch['test'],
@@ -408,7 +406,6 @@ def get_trainer_from_cfg(cfg: DictConfig, lightning_module, stopper, profiler: s
                              num_sanity_val_steps=0,
                              callbacks=callback_list,
                              reload_dataloaders_every_n_epochs=1,
-                             progress_bar_refresh_rate=refresh_rate,
                              profiler=profiler,
                              log_every_n_steps=1)
     torch.cuda.empty_cache()

--- a/deepethogram/callbacks.py
+++ b/deepethogram/callbacks.py
@@ -20,10 +20,10 @@ class DebugCallback(Callback):
     def on_init_end(self, trainer):
         log.info('on init start')
 
-    def on_train_batch_start(self, trainer, pl_module, batch, batch_idx, dataloader_idx):
+    def on_train_batch_start(self, trainer, pl_module, batch, batch_idx):
         log.debug('on train batch start')
 
-    def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx):
+    def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
         log.debug('on train batch end')
 
     def on_train_epoch_start(self, trainer, pl_module):
@@ -94,16 +94,16 @@ class FPSCallback(Callback):
 
         pl_module.metrics.buffer.append(split, {'fps': fps})
 
-    def on_train_batch_start(self, trainer, pl_module, batch, batch_idx, dataloader_idx):
+    def on_train_batch_start(self, trainer, pl_module, batch, batch_idx):
         self.start_timer('train')
 
-    def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx):
+    def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
         self.end_batch('train', batch, pl_module)
 
-    def on_validation_batch_start(self, trainer, pl_module, batch, batch_idx, dataloader_idx):
+    def on_validation_batch_start(self, trainer, pl_module, batch, batch_idx):
         self.start_timer('val')
 
-    def on_validation_batch_end(self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx):
+    def on_validation_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
         self.end_batch('val', batch, pl_module)
 
     def on_test_batch_start(self, trainer, pl_module, batch, batch_idx, dataloader_idx):
@@ -204,10 +204,10 @@ class ExampleImagesCallback(Callback):
     def on_test_epoch_end(self, trainer, pl_module):
         self.reset_cnt(pl_module, 'test')
 
-    def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx):
+    def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
         pl_module.viz_cnt['train'] += 1
 
-    def on_validation_batch_end(self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx):
+    def on_validation_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
         pl_module.viz_cnt['val'] += 1
 
     def on_test_batch_end(self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx):

--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,5 @@ setuptools.setup(name='deepethogram',
                  install_requires=[
                      'chardet<4.0', 'h5py', 'kornia>=0.5', 'matplotlib', 'numpy', 'omegaconf>=2',
                      'opencv-python-headless', 'opencv-transforms', 'pandas<1.4', 'PySide2', 'scikit-learn<1.1',
-                     'scipy<1.8', 'tqdm', 'vidio', 'pytorch_lightning>=1.5.10'
+                     'scipy<1.8', 'tqdm', 'vidio', 'pytorch_lightning>=2.0.7'
                  ])


### PR DESCRIPTION
Hi!

Thanks for the cool pipeline. I was facing some crashes when I tried to run the code with PyTorch 2.x and PyTorch Lightning 2.0.7 so I fixed them. I used the nightly of 2.1 but it should be the same behaviour for the 2.0 release.
I was able to run the complete flow of Colab notebook and passed all the tests. The environment used was:

```
(deepethogram_39n) ➜  deepethogram pip freeze
aiohttp==3.8.5
aiosignal==1.3.1
antlr4-python3-runtime==4.9.3
async-timeout==4.0.3
attrs==23.1.0
brotlipy==0.7.0
certifi==2023.7.22
cffi @ file:///croot/cffi_1670423208954/work
chardet==3.0.4
charset-normalizer @ file:///tmp/build/80754af9/charset-normalizer_1630003229654/work
contourpy==1.1.0
cryptography @ file:///croot/cryptography_1677533068310/work
cycler==0.11.0
-e git+https://github.com/jbohnslav/deepethogram.git@a2565bb6a19f3f71ae4231dfd947a98ab9b3ae0f#egg=deepethogram
exceptiongroup==1.1.3
filelock @ file:///croot/filelock_1672387128942/work
fonttools==4.42.1
frozenlist==1.4.0
fsspec==2023.6.0
gmpy2 @ file:///tmp/build/80754af9/gmpy2_1645438755360/work
h5py==3.9.0
idna @ file:///croot/idna_1666125576474/work
importlib-resources==6.0.1
iniconfig==2.0.0
Jinja2 @ file:///croot/jinja2_1666908132255/work
joblib==1.3.2
kiwisolver==1.4.5
kornia==0.7.0
lightning-utilities==0.9.0
MarkupSafe @ file:///opt/conda/conda-bld/markupsafe_1654597864307/work
matplotlib==3.7.2
mkl-fft==1.3.6
mkl-random @ file:///work/mkl/mkl_random_1682950433854/work
mkl-service==2.4.0
mpmath @ file:///croot/mpmath_1690848262763/work
multidict==6.0.4
networkx @ file:///croot/networkx_1690561992265/work
numpy==1.22.4
omegaconf==2.3.0
opencv-python-headless==4.8.0.76
opencv-transforms==0.0.6
packaging==23.1
pandas==1.3.5
Pillow==9.4.0
pluggy==1.3.0
protobuf==4.24.2
pycparser @ file:///tmp/build/80754af9/pycparser_1636541352034/work
pyOpenSSL @ file:///croot/pyopenssl_1690223430423/work
pyparsing==3.0.9
PySide2==5.13.2
PySocks @ file:///tmp/build/80754af9/pysocks_1605305812635/work
pytest==7.4.1
python-dateutil @ file:///home/conda/feedstock_root/build_artifacts/python-dateutil_1626286286081/work
pytorch-lightning==2.0.7
pytz @ file:///home/conda/feedstock_root/build_artifacts/pytz_1680088766131/work
PyYAML @ file:///croot/pyyaml_1670514731622/work
requests @ file:///croot/requests_1690400202158/work
scikit-learn==1.0.2
scipy==1.7.3
shiboken2==5.13.2
six @ file:///home/conda/feedstock_root/build_artifacts/six_1620240208055/work
sympy @ file:///croot/sympy_1668202399572/work
tensorboardX==2.6.2.2
threadpoolctl==3.2.0
tomli==2.0.1
torch==2.1.0.dev20230831
torchaudio==2.2.0.dev20230901
torchmetrics==1.1.0
torchvision==0.16.0.dev20230831
tqdm==4.66.1
triton==2.1.0
typing_extensions @ file:///croot/typing_extensions_1690297465030/work
urllib3 @ file:///croot/urllib3_1686163155763/work
vidio==0.0.4
yarl==1.9.2
zipp==3.16.2
```

The Python version was `3.9.7` and here are the result of the tests:

```
(deepethogram_39n) ➜  deepethogram git:(pytorch2.0) ✗ pytest tests
============================================================================= test session starts =============================================================================
platform linux -- Python 3.9.7, pytest-7.4.1, pluggy-1.3.0
rootdir: /data/yanar/deepethogram
collected 18 items

tests/test_data.py .                                                                                                                                                    [  5%]
tests/test_flow_generator.py .                                                                                                                                          [ 11%]
tests/test_gui.py .                                                                                                                                                     [ 16%]
tests/test_models.py .                                                                                                                                                  [ 22%]
tests/test_projects.py ........                                                                                                                                         [ 66%]
tests/test_z_score.py .                                                                                                                                                 [ 72%]
tests/test_zz_commandline.py .....                                                                                                                                      [100%]

======================================================================= 18 passed in 412.60s (0:06:52) ========================================================================
```

I think it'll be complicated to merge this considering that there're no releases of DeepEthogram and that could mess the installation in environments with 1.x but it can be helpful for those working with PyTorch 2.x.
