### PR TITLE
Fix #116 and #129: label import bug and matplotlib backend conflict

### DIFF
--- a/deepethogram/feature_extractor/train.py
+++ b/deepethogram/feature_extractor/train.py
@@ -46,7 +46,6 @@ log = logging.getLogger(__name__)
 
 
 def feature_extractor_train(cfg: DictConfig) -> nn.Module:
-    plt.switch_backend("agg")
     """Trains feature extractor models from a configuration.
 
     Parameters
@@ -59,6 +58,7 @@ def feature_extractor_train(cfg: DictConfig) -> nn.Module:
     nn.Module
         Trained feature extractor
     """
+    plt.switch_backend("agg")
     cfg = projects.setup_run(cfg)
 
     log.info("args: {}".format(" ".join(sys.argv)))

--- a/deepethogram/feature_extractor/train.py
+++ b/deepethogram/feature_extractor/train.py
@@ -42,12 +42,11 @@ warnings.filterwarnings(
     "and test dataloaders.",
 )
 
-plt.switch_backend("agg")
-
 log = logging.getLogger(__name__)
 
 
 def feature_extractor_train(cfg: DictConfig) -> nn.Module:
+    plt.switch_backend("agg")
     """Trains feature extractor models from a configuration.
 
     Parameters

--- a/deepethogram/flow_generator/train.py
+++ b/deepethogram/flow_generator/train.py
@@ -32,12 +32,11 @@ warnings.filterwarnings(
 
 flow_generators = utils.get_models_from_module(models, get_function=False)
 
-plt.switch_backend("agg")
-
 log = logging.getLogger(__name__)
 
 
 def flow_generator_train(cfg: DictConfig) -> nn.Module:
+    plt.switch_backend("agg")
     """Trains flow generator models from a configuration.
 
     Parameters

--- a/deepethogram/flow_generator/train.py
+++ b/deepethogram/flow_generator/train.py
@@ -36,7 +36,6 @@ log = logging.getLogger(__name__)
 
 
 def flow_generator_train(cfg: DictConfig) -> nn.Module:
-    plt.switch_backend("agg")
     """Trains flow generator models from a configuration.
 
     Parameters
@@ -49,6 +48,7 @@ def flow_generator_train(cfg: DictConfig) -> nn.Module:
     nn.Module
         Trained flow generator
     """
+    plt.switch_backend("agg")
     cfg = projects.setup_run(cfg)
     log.info("args: {}".format(" ".join(sys.argv)))
     # only two custom overwrites of the configuration file

--- a/deepethogram/projects.py
+++ b/deepethogram/projects.py
@@ -171,7 +171,12 @@ def add_label_to_project(path_to_labels: Union[str, os.PathLike], path_to_video)
     if os.path.isfile(label_dst):
         warnings.warn("Label already exists in destination {}, overwriting...".format(label_dst))
 
-    df = pd.read_csv(path_to_labels, index_col=0)
+    df = pd.read_csv(path_to_labels)
+    # Drop unnamed index column if present (DEG-generated CSVs have one)
+    first_col = df.columns[0]
+    if first_col == "" or str(first_col).startswith("Unnamed"):
+        df = df.drop(columns=[first_col])
+
     if "none" in list(df.columns):
         df = df.rename(columns={"none": "background"})
     if "background" not in list(df.columns):

--- a/deepethogram/sequence/train.py
+++ b/deepethogram/sequence/train.py
@@ -19,10 +19,9 @@ from deepethogram.sequence.models.tgm import TGM, TGMJ
 
 log = logging.getLogger(__name__)
 
-plt.switch_backend("agg")
-
 
 def sequence_train(cfg: DictConfig) -> nn.Module:
+    plt.switch_backend("agg")
     """Trains sequence models from a configuration.
 
     Parameters

--- a/deepethogram/sequence/train.py
+++ b/deepethogram/sequence/train.py
@@ -21,7 +21,6 @@ log = logging.getLogger(__name__)
 
 
 def sequence_train(cfg: DictConfig) -> nn.Module:
-    plt.switch_backend("agg")
     """Trains sequence models from a configuration.
 
     Parameters
@@ -34,6 +33,7 @@ def sequence_train(cfg: DictConfig) -> nn.Module:
     nn.Module
         Trained sequence model
     """
+    plt.switch_backend("agg")
     cfg = projects.setup_run(cfg)
     log.info("args: {}".format(" ".join(sys.argv)))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "deepethogram"
-version = "0.3.0"
+version = "0.4.0"
 description = "Temporal action detection for biology"
 readme = "README.md"
 authors = [

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -115,5 +115,80 @@ def test_add_external_label():
     projects.add_label_to_project(labelfile, videofile)
 
 
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_add_label_deg_style_csv(tmp_path):
+    """Test add_label_to_project with DEG-generated CSV (has unnamed index column)."""
+    make_project_from_archive()
+    mousedir = os.path.join(project_path, "DATA", "mouse06")
+    videofile = os.path.join(mousedir, "mouse06.h5")
+
+    # Create a DEG-style CSV with unnamed numeric index
+    csv_path = tmp_path / "labels_with_index.csv"
+    csv_path.write_text(
+        ",background,behavior1,behavior2\n"
+        "0,1,0,0\n"
+        "1,0,1,0\n"
+        "2,0,0,1\n"
+    )
+
+    result = projects.add_label_to_project(str(csv_path), videofile)
+    df = pd.read_csv(result, index_col=0)
+    assert "background" in df.columns
+    assert "behavior1" in df.columns
+    assert "behavior2" in df.columns
+    assert df.shape[1] == 3  # background + 2 behaviors
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_add_label_external_csv_no_index(tmp_path):
+    """Test add_label_to_project with external CSV (no index column, no background).
+
+    Regression test for GitHub issue #116: the old code used index_col=0 which
+    silently ate the first data column when no index column was present.
+    """
+    make_project_from_archive()
+    mousedir = os.path.join(project_path, "DATA", "mouse06")
+    videofile = os.path.join(mousedir, "mouse06.h5")
+
+    # Create a user-provided CSV without index or background column
+    csv_path = tmp_path / "labels_no_index.csv"
+    csv_path.write_text(
+        "behavior1,behavior2\n"
+        "0,0\n"
+        "1,0\n"
+        "0,1\n"
+    )
+
+    result = projects.add_label_to_project(str(csv_path), videofile)
+    df = pd.read_csv(result, index_col=0)
+    assert "background" in df.columns, "background column should be auto-inserted"
+    assert "behavior1" in df.columns, "behavior1 should NOT be eaten by index_col"
+    assert "behavior2" in df.columns
+    assert df.shape[1] == 3  # background + behavior1 + behavior2
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_add_label_external_csv_with_background_no_index(tmp_path):
+    """Test external CSV that has background but no index column."""
+    make_project_from_archive()
+    mousedir = os.path.join(project_path, "DATA", "mouse06")
+    videofile = os.path.join(mousedir, "mouse06.h5")
+
+    csv_path = tmp_path / "labels_bg_no_index.csv"
+    csv_path.write_text(
+        "background,behavior1,behavior2\n"
+        "1,0,0\n"
+        "0,1,0\n"
+        "0,0,1\n"
+    )
+
+    result = projects.add_label_to_project(str(csv_path), videofile)
+    df = pd.read_csv(result, index_col=0)
+    assert "background" in df.columns
+    assert "behavior1" in df.columns
+    assert "behavior2" in df.columns
+    assert df.shape[1] == 3
+
+
 if __name__ == "__main__":
     test_add_external_label()

--- a/uv.lock
+++ b/uv.lock
@@ -331,7 +331,7 @@ wheels = [
 
 [[package]]
 name = "deepethogram"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "chardet" },


### PR DESCRIPTION
## Fixes

### Fix #116: `add_label_to_project()` silently deletes first behavior column

The old code used `pd.read_csv(path, index_col=0)` which assumes every CSV has a DEG-style unnamed numeric index column. External CSVs without one had their first data column silently consumed as the index.

**Fix:** Read without `index_col` and explicitly detect/drop unnamed index columns.

**Tests added:** Three new test cases covering DEG-style CSVs, external CSVs without index, and external CSVs with background but no index.

### Fix #129: matplotlib backend conflict when importing training modules

`plt.switch_backend('agg')` was called at module level in `flow_generator/train.py`, `feature_extractor/train.py`, and `sequence/train.py`. This killed interactive matplotlib for anyone importing these modules in notebooks or scripts.

**Fix:** Moved the call inside the training functions. Training still uses the `agg` backend; importing the module no longer overrides the user's backend.

## Testing

All 28 tests pass (`pytest -v -m 'not gpu'`), including 3 new tests for #116.